### PR TITLE
HOTFIX : use pdal instead of laspy for interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ source bash/setup_environment/setup_env.sh  # with cudatoolkit
 source bash/setup_environment/setup_env_cpu_only.sh  # cpu version only
 
 # activate using
-conda activate lidar_deep_segmentation
+conda activate lidar_multiclass
 ```
 
 ### Run inference from package
@@ -57,7 +57,7 @@ If you are interested in running inference from anywhere, you can install code a
 
 ```
 # activate an env matching ./bash/setup_env.sh requirements.
-conda activate lidar_deep_segmentation
+conda activate lidar_multiclass
 
 # install the package
 pip install --upgrade https://github.com/IGNF/lidar-deep-segmentation/tarball/main  # from github directly

--- a/bash/setup_environment/requirements.yml
+++ b/bash/setup_environment/requirements.yml
@@ -1,17 +1,17 @@
-name: lidar_deep_segmentation
+name: lidar_multiclass
 channels:
   - conda-forge
   - anaconda
   - comet_ml
   - pytorch
 dependencies:
-  - python==3.9
+  - python==3.9.*
   - pip
   # --------- numpy --------- #
   - numpy==1.20
   # --------- geo --------- #
-  - laspy
   - pygeos
+  - laspy
   - python-pdal  # useful for data preparation
   # --------- loggers --------- #
   - comet_ml

--- a/bash/setup_environment/setup_env.sh
+++ b/bash/setup_environment/setup_env.sh
@@ -3,7 +3,7 @@ set -e
 # SETUP
 conda install -y mamba -n base -c conda-forge
 mamba env create -f bash/setup_environment/requirements.yml
-conda activate lidar_deep_segmentation
+conda activate lidar_multiclass
 
 # INSTALL
 export PYTORCHVERSION="1.10.1"
@@ -13,4 +13,4 @@ mamba install -y pytorch==$PYTORCHVERSION torchvision==$TORCHVISIONVERSION cudat
 mamba install -y pyg==2.0.3 -c pytorch -c pyg -c conda-forge
 FORCE_CUDA=1 pip install torch-points-kernels --no-cache
 pip install numba==0.55.1 numpy==1.20.0 # revert inconsistent torch-points-kernel dependencies
-mamba install pytorch-lightning==1.5.9 -c conda-forge
+mamba install -y pytorch-lightning==1.5.9 -c conda-forge

--- a/bash/setup_environment/setup_env_cpu_only.sh
+++ b/bash/setup_environment/setup_env_cpu_only.sh
@@ -3,7 +3,7 @@ set -e
 # SETUP
 conda install -y mamba -n base -c conda-forge
 mamba env create -f bash/setup_environment/requirements.yml
-conda activate lidar_deep_segmentation
+conda activate lidar_multiclass
 
 # INSTALL
 export PYTORCHVERSION="1.10.1"

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="lidar_multiclass",
-    version="1.6.3",
+    version="1.6.10",
     description="Multiclass Semantic Segmentation for Lidar Point Cloud",
     author="Charles GAYDON",
     author_email="",


### PR DESCRIPTION
This is needed to be robust to custom extra bytes that break laspy write operation.